### PR TITLE
Update build.gradle

### DIFF
--- a/platform_device_id/android/build.gradle
+++ b/platform_device_id/android/build.gradle
@@ -2,7 +2,6 @@ group 'com.di1shuai.platform_device_id'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
removed Kotlin version constraint to follow the main and work for newer versions of android